### PR TITLE
docs(rust): add TOC to README and configure toc settings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,10 @@
 theme: jekyll-theme-cayman
+
+toc:
+  min_level: 2
+  max_level: 3
+  ordered_list: false
+  no_toc_section_class: no_toc_section
+  list_class: toc
+  sublist_class: toc-sublist
+  item_class: toc-entry

--- a/docs/Rust/README.md
+++ b/docs/Rust/README.md
@@ -1,3 +1,9 @@
+---
+title: Rust Cheat Sheet
+description: Rust Cheat Sheet
+layout: default
+---
+
 * TOC
 {:toc}
 


### PR DESCRIPTION
- Add a Table of Contents (TOC) to the Rust README.
- Introduce toc settings in _config.yml to customize the TOC appearance and behavior.