### PR TITLE
docs(rust): update file system and command line arguments examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ This repository contains a comprehensive collection of cheat sheets for various 
 
 | Category | Subcategory | Update Status |
 |----------|-------------|---------------|
-| Kubernetes | [Kubectl](docs/Kubernetes/KUBECTL.md) | Updated |
-| Kubernetes | [YAML](docs/Kubernetes/YAML.md) | Updated |
-| Linux | [Commands](docs/Linux/README.md) | Updated |
-| Network | [Tools](docs/Network/TOOLS.md) | Updated |
-| Prometheus | [PromQL](docs/Prometheus/PromQL.md) | Updated |
-| Rust| [Rust](docs/Rust/README.md) | Updated |
+| Kubernetes | [Kubectl](docs/Kubernetes/KUBECTL.md) | ❌ |
+| Kubernetes | [YAML](docs/Kubernetes/YAML.md) | ❌ |
+| Linux | [Commands](docs/Linux/README.md) | ❌ |
+| Network | [Tools](docs/Network/TOOLS.md) | ❌ |
+| Prometheus | [PromQL](docs/Prometheus/PromQL.md) | ❌ |
+| Rust| [Rust](docs/Rust/README.md) | ✅ |
 
 ## Usage
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,10 +1,1 @@
 theme: jekyll-theme-cayman
-
-toc:
-  min_level: 2
-  max_level: 3
-  ordered_list: false
-  no_toc_section_class: no_toc_section
-  list_class: toc
-  sublist_class: toc-sublist
-  item_class: toc-entry


### PR DESCRIPTION
- Add detailed explanations of `Path` and `File` structs in the Rust documentation.
- Include new code examples demonstrating file I/O operations and handling command line arguments.
- Emphasize the use of `Path::new`, `File::create`, `File::open`, and `env::args` in the updated examples.

This change enhances the Rust documentation with more comprehensive information on working with file system paths and files, as well as parsing command line arguments. The additions are intended to assist developers in understanding standard library features related to these topics.